### PR TITLE
Add `fromBuffer` support for DPT13.

### DIFF
--- a/src/dptlib/dpt13.js
+++ b/src/dptlib/dpt13.js
@@ -7,6 +7,15 @@
 // DPT13: 4-byte signed value
 //
 
+exports.fromBuffer = function (buf) {
+  if (buf.length != 4) {
+    knxLog.get().warn('DPT13: Buffer should be 4 bytes long, got', buf.length)
+    return null
+  } else {
+    return buf.readIntBE(0, 4)
+  }
+}
+
 // DPT13 base type info
 exports.basetype = {
   bitlength: 32,


### PR DESCRIPTION
Add `fromBuffer` support for DPT13.
(copied from DPT12, but unsigned)

Only slightly tested, but positive values are fine.