### PR TITLE
fix: issue where DPT9 was giving error

### DIFF
--- a/src/dptlib/dpt9.ts
+++ b/src/dptlib/dpt9.ts
@@ -12,7 +12,7 @@ import { frexp, hasProp, ldexp } from '../utils'
 //
 
 const config: DatapointConfig = {
-	id: 'DPT2',
+	id: 'DPT9',
 	formatAPDU: (value) => {
 		const apdu_data = Buffer.alloc(2)
 		if (!isFinite(value)) {


### PR DESCRIPTION
There was an error trying to read value from buffer of DPT9.001. This PR fixes that issue 
```
        throw Error(`Unsupported DPT: ${dptid}`);
              ^
Error: Unsupported DPT: 9.001
    at Object.resolve (/home/lenovo/learning/enmatter/node_modules/.pnpm/knxultimate@2.1.2/node_modules/knxultimate/build/dptlib/index.js:117:15)
    at handleKnxEvent (/home/lenovo/learning/enmatter/apps/server/src/plugins/knx/handleKnxEvent.ts:20:54)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Node.js v18.16.1
```