### PR TITLE
feat(secure): add KNX/IP Secure Tunneling TS skeleton (AES-CCM, sessi…

### DIFF
--- a/README-secure.md
+++ b/README-secure.md
@@ -1,0 +1,44 @@
+# KNX/IP Secure Tunneling — Integration Notes
+
+This PR adds a **TypeScript skeleton** to enable KNX/IP Secure (Tunneling only).
+
+## What’s included
+- AES-128-CCM helpers (`src/secure/ccm.ts`)
+- Session & counters (`src/secure/session.ts`)
+- Secure adapter for wrap/unwrap (`src/secure/adapter.ts`)
+- Keyring loader (JSON, `src/secure/keyring.ts`)
+- Frame helpers (stubs) (`src/secure/frame.ts`)
+- TCP transport with reassembly (`src/transport/tcp-client.ts`)
+- Types (`src/secure/types.ts`)
+- Smoke test for CCM (`test/ccm-smoke.test.ts`)
+
+## Next steps (TODO)
+1. **Secure Wrapper Layout**
+   - Confirm the exact field order/lengths for the secure wrapper around cEMI.
+   - Replace the placeholder where we currently do `[seq(4B) | ciphertext | tag]`.
+2. **AAD Definition**
+   - Confirm which KNXnet/IP header bytes must be included as AAD (spec requirement).
+   - Update `buildKnxHeaderForAAD` and `parseSecureKnxFrame` accordingly.
+3. **Nonce Format**
+   - Align nonce = saltTX/saltRX + (seq or fields required by spec).
+   - Update `KnxSecureSession.buildNonceTX/RX` to match the standard.
+4. **KDF (manual path)**
+   - If not using ETS keyring-provided tunnel keys, implement the official KDF based on commissioning/auth material.
+5. **Handshake (if required by target device)**
+   - Add `secure/handshake.ts` to perform any secure hello/exchange expected by the gateway.
+6. **.knxkeys XML Support**
+   - Add XML parsing (e.g., `xml2js`) and normalize to `KeyringObject`.
+
+## How to wire in the client
+- Use `TcpTunnelingClient` when `secure===true`.
+- After `CONNECT_REQUEST/RESPONSE`, init session & adapter from keyring (preferred).
+- On send: build AAD → `wrapTunnelingRequest` → `buildKnxSecureFrame` → `tcp.send`.
+- On receive: `parseSecureKnxFrame` → `unwrapSecurePayload` → handle plain cEMI.
+
+## Tests
+- Run `test/ccm-smoke.test.ts` to validate AES-CCM roundtrip.
+- Add device integration tests once wrapper/AAD/nonce are finalized.
+
+---
+
+> Once we lock the exact wrapper/AAD/nonce from a known-good device capture, I’ll update the offsets and remove the TODOs.

--- a/src/secure/adapter.ts
+++ b/src/secure/adapter.ts
@@ -1,0 +1,44 @@
+import { KnxSecureSession } from "./session";
+import { ccmEncrypt, ccmDecrypt } from "./ccm";
+
+/**
+ * Wraps/unwraps KNX Tunneling payloads using KNX/IP Secure.
+ * AAD should be the KNXnet/IP header (without the encrypted body).
+ * TODO: align wrapper layout with the official spec.
+ */
+export class SecureChannelAdapter {
+  private readonly sess: KnxSecureSession;
+  private readonly maxWindow = 4096;
+
+  constructor(session: KnxSecureSession) {
+    this.sess = session;
+  }
+
+  /** Produce secure payload from plain cEMI. */
+  public wrapTunnelingRequest(plainCemi: Buffer, aad: Buffer | null): { seq: number; securePayload: Buffer } {
+    const seq = this.sess.nextSeqTX();
+    const nonce = this.sess.buildNonceTX(seq);
+    const { ciphertext, tag } = ccmEncrypt(this.sess.txKey, nonce, aad, plainCemi, this.sess.authTagLen);
+    const seqBuf = Buffer.allocUnsafe(4); seqBuf.writeUInt32BE(seq >>> 0, 0);
+    // TODO: add Secure Header fields if required by the spec
+    const securePayload = Buffer.concat([seqBuf, ciphertext, tag]);
+    return { seq, securePayload };
+  }
+
+  /** Extract plain cEMI from secure payload. */
+  public unwrapSecurePayload(securePayload: Buffer, aad: Buffer | null): { seq: number; plainCemi: Buffer } {
+    if (securePayload.length < 4 + this.sess.authTagLen) {
+      throw new Error("KNX Secure: secure payload too short.");
+    }
+    const seq = securePayload.readUInt32BE(0) >>> 0;
+    if (seq + this.maxWindow < this.sess.rxCounter) {
+      throw new Error("KNX Secure: frame exceeds RX window.");
+    }
+    const tag = securePayload.subarray(securePayload.length - this.sess.authTagLen);
+    const ciphertext = securePayload.subarray(4, securePayload.length - this.sess.authTagLen);
+    const nonce = this.sess.buildNonceRX(seq);
+    const plainCemi = ccmDecrypt(this.sess.rxKey, nonce, aad, ciphertext, tag, this.sess.authTagLen);
+    this.sess.acceptAndAdvanceRX(seq);
+    return { seq, plainCemi };
+  }
+}

--- a/src/secure/ccm.ts
+++ b/src/secure/ccm.ts
@@ -1,0 +1,31 @@
+import crypto from "node:crypto";
+
+/** AES-128-CCM encrypt. `key` must be 16 bytes. */
+export function ccmEncrypt(
+  key: Buffer,
+  nonce: Buffer,
+  aad: Buffer | null,
+  plaintext: Buffer,
+  tagLen: number = 16
+): { ciphertext: Buffer; tag: Buffer } {
+  const cipher = crypto.createCipheriv("aes-128-ccm", key, nonce, { authTagLength: tagLen });
+  if (aad && aad.length) cipher.setAAD(aad, { plaintextLength: plaintext.length });
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { ciphertext, tag };
+}
+
+/** AES-128-CCM decrypt. Throws if auth fails. */
+export function ccmDecrypt(
+  key: Buffer,
+  nonce: Buffer,
+  aad: Buffer | null,
+  ciphertext: Buffer,
+  tag: Buffer,
+  tagLen: number = 16
+): Buffer {
+  const decipher = crypto.createDecipheriv("aes-128-ccm", key, nonce, { authTagLength: tagLen });
+  if (aad && aad.length) decipher.setAAD(aad, { plaintextLength: ciphertext.length });
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}

--- a/src/secure/frame.ts
+++ b/src/secure/frame.ts
@@ -1,0 +1,50 @@
+/**
+ * Minimal helpers to construct/parse KNXnet/IP frames for secure tunneling.
+ * NOTE: These are STUBS. Replace header fields/offsets with the official spec.
+ */
+
+export interface KnxHeaderFields {
+  serviceType: number;   // e.g., 0x0420 for TUNNELING_REQUEST (check spec)
+  channelId: number;
+  sequence: number;      // KNXnet/IP sequence (not the secure seq)
+  // ...other fields as needed
+}
+
+/** Build the AAD from KNXnet/IP header fields (without encrypted body). */
+export function buildKnxHeaderForAAD(h: KnxHeaderFields): Buffer {
+  // TODO: build the exact header bytes that must be authenticated (AAD)
+  const buf = Buffer.alloc(8);
+  buf.writeUInt16BE(h.serviceType, 0);
+  buf.writeUInt8(h.channelId & 0xff, 2);
+  buf.writeUInt8(h.sequence & 0xff, 3);
+  // pad / add fields as required by the spec
+  return buf;
+}
+
+/** Wrap securePayload into a KNXnet/IP "Secure" frame. */
+export function buildKnxSecureFrame(h: KnxHeaderFields, securePayload: Buffer): Buffer {
+  const aad = buildKnxHeaderForAAD(h);
+  const totalLength = aad.length + securePayload.length + 6; // 6 = example header bytes (stub)
+  const out = Buffer.alloc(6);
+  // Common KNXnet/IP header parts (STUB):
+  out.writeUInt8(0x06, 0); // header size?
+  out.writeUInt8(0x10, 1); // protocol version?
+  out.writeUInt16BE(h.serviceType, 2);
+  out.writeUInt16BE(totalLength, 4);
+  return Buffer.concat([out, aad, securePayload]);
+}
+
+/** Parse a KNXnet/IP frame into { aad, securePayload } for decryption. */
+export function parseSecureKnxFrame(frame: Buffer): { aad: Buffer; securePayload: Buffer } {
+  if (frame.length < 6) throw new Error("Frame too short");
+  const totalLength = frame.readUInt16BE(4);
+  if (totalLength !== frame.length) {
+    // some stacks may have padding; adapt if needed
+  }
+  // STUB: assume next bytes after the 6-byte header are the AAD (8 bytes as in buildKnxHeaderForAAD)
+  const aadLen = 8;
+  if (frame.length < 6 + aadLen + 1) throw new Error("Frame too short for AAD");
+  const aad = frame.subarray(6, 6 + aadLen);
+  const securePayload = frame.subarray(6 + aadLen);
+  return { aad, securePayload };
+}

--- a/src/secure/keyring.ts
+++ b/src/secure/keyring.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import { KeyringObject, SecureParamsManual, TunnelKeys } from "./types";
+
+/** Loads a .knxkeys JSON. XML parsing not implemented yet. */
+export function loadKeyring(path: string): KeyringObject {
+  const raw = fs.readFileSync(path, "utf8");
+  try {
+    const obj = JSON.parse(raw);
+    return obj as KeyringObject;
+  } catch {
+    throw new Error("Keyring XML parsing not yet implemented (expects JSON).");
+  }
+}
+
+/** Resolve tunnel keys by userId/Individual Address. */
+export function resolveTunnelKeys(
+  keyring: KeyringObject,
+  params: SecureParamsManual
+): TunnelKeys {
+  const cand = keyring.tunnels.find(t =>
+    t.userId === params.tunnelUserId &&
+    (!params.deviceIndividualAddress || t.individualAddress === params.deviceIndividualAddress)
+  );
+  if (!cand) {
+    throw new Error("KNX Secure: matching tunnel not found in keyring.");
+  }
+  if (!cand.keyTXHex || !cand.keyRXHex || !cand.nonceSaltTXHex || !cand.nonceSaltRXHex) {
+    throw new Error("KNX Secure: incomplete tunnel entry (keys/salts missing).");
+  }
+  return {
+    keyTX: Buffer.from(cand.keyTXHex, "hex"),
+    keyRX: Buffer.from(cand.keyRXHex, "hex"),
+    nonceSaltTX: Buffer.from(cand.nonceSaltTXHex, "hex"),
+    nonceSaltRX: Buffer.from(cand.nonceSaltRXHex, "hex"),
+    tagLength: cand.tagLength ?? 16,
+  };
+}
+
+/** Manual derivation placeholder. Replace with spec KDF. */
+export function deriveFromManual(params: SecureParamsManual): TunnelKeys {
+  if (!params.authCodeHex) {
+    throw new Error("KNX Secure: authCodeHex required for manual derivation (TODO KDF).");
+  }
+  const base = Buffer.from(params.authCodeHex, "hex");
+  if (base.length < 16) throw new Error("authCodeHex too short");
+  const keyTX = base.subarray(0, 16);
+  const keyRX = base.subarray(0, 16);
+  const saltTX = (base.length >= 24) ? base.subarray(16, 24) : Buffer.concat([base.subarray(0, 8)]);
+  const saltRX = (base.length >= 32) ? base.subarray(24, 32) : Buffer.concat([base.subarray(0, 8)]);
+  return { keyTX, keyRX, nonceSaltTX: saltTX, nonceSaltRX: saltRX, tagLength: 16 };
+}

--- a/src/secure/session.ts
+++ b/src/secure/session.ts
@@ -1,0 +1,60 @@
+import { TunnelKeys } from "./types";
+
+/**
+ * Manages keys, counters and nonce building for TX/RX.
+ * TODO: align nonce format to KNX/IP Secure Tunneling.
+ */
+export class KnxSecureSession {
+  private keyTX: Buffer;
+  private keyRX: Buffer;
+  private saltTX: Buffer;
+  private saltRX: Buffer;
+  private tagLength: number;
+
+  private seqTX = 0 >>> 0;
+  private seqRX = 0 >>> 0;
+
+  constructor(keys: TunnelKeys) {
+    this.keyTX = keys.keyTX;
+    this.keyRX = keys.keyRX;
+    this.saltTX = keys.nonceSaltTX;
+    this.saltRX = keys.nonceSaltRX;
+    this.tagLength = keys.tagLength ?? 16;
+    if (this.keyTX.length !== 16 || this.keyRX.length !== 16) {
+      throw new Error("KNX Secure: keys must be 16 bytes (AES-128).");
+    }
+  }
+
+  public nextSeqTX(): number {
+    const s = this.seqTX >>> 0;
+    this.seqTX = (this.seqTX + 1) >>> 0;
+    return s;
+  }
+
+  public get rxCounter(): number { return this.seqRX >>> 0; }
+
+  public acceptAndAdvanceRX(seq: number): void {
+    if ((seq >>> 0) < (this.seqRX >>> 0)) {
+      throw new Error("KNX Secure: replay detected (seq out of order).");
+    }
+    this.seqRX = (seq + 1) >>> 0;
+  }
+
+  public buildNonceTX(seq: number): Buffer {
+    const n = Buffer.alloc(12);
+    this.saltTX.copy(n, 0, 0, Math.min(8, this.saltTX.length));
+    n.writeUInt32BE(seq >>> 0, 8);
+    return n;
+  }
+
+  public buildNonceRX(seq: number): Buffer {
+    const n = Buffer.alloc(12);
+    this.saltRX.copy(n, 0, 0, Math.min(8, this.saltRX.length));
+    n.writeUInt32BE(seq >>> 0, 8);
+    return n;
+  }
+
+  public get txKey(): Buffer { return this.keyTX; }
+  public get rxKey(): Buffer { return this.keyRX; }
+  public get authTagLen(): number { return this.tagLength; }
+}

--- a/src/secure/types.ts
+++ b/src/secure/types.ts
@@ -1,0 +1,26 @@
+export interface SecureParamsManual {
+  tunnelUserId: number;
+  deviceIndividualAddress?: string;
+  authCodeHex?: string;
+  commissioningPassword?: string;
+}
+
+export interface TunnelKeys {
+  keyTX: Buffer;
+  keyRX: Buffer;
+  nonceSaltTX: Buffer;
+  nonceSaltRX: Buffer;
+  tagLength?: number;
+}
+
+export interface KeyringObject {
+  tunnels: Array<{
+    userId: number;
+    individualAddress?: string;
+    keyTXHex?: string;
+    keyRXHex?: string;
+    nonceSaltTXHex?: string;
+    nonceSaltRXHex?: string;
+    tagLength?: number;
+  }>;
+}

--- a/src/transport/tcp-client.ts
+++ b/src/transport/tcp-client.ts
@@ -1,0 +1,54 @@
+import net from "node:net";
+
+export interface TcpTunnelingOptions {
+  host: string;
+  port?: number;
+  onFrame: (frame: Buffer) => void;
+  onClose?: () => void;
+  onError?: (err: Error) => void;
+}
+
+export class TcpTunnelingClient {
+  private socket: net.Socket | null = null;
+  private buf = Buffer.alloc(0);
+  private readonly opt: TcpTunnelingOptions;
+
+  constructor(opt: TcpTunnelingOptions) {
+    this.opt = opt;
+  }
+
+  public connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const s = net.createConnection(this.opt.port ?? 3671, this.opt.host);
+      this.socket = s;
+      s.once("connect", () => resolve());
+      s.on("data", (chunk) => this.onData(chunk));
+      s.on("error", (e) => this.opt.onError?.(e as Error));
+      s.on("close", () => this.opt.onClose?.());
+    });
+  }
+
+  public send(frame: Buffer): void {
+    if (!this.socket) throw new Error("TCP not connected");
+    this.socket.write(frame);
+  }
+
+  public close(): void {
+    try { this.socket?.end(); } catch {}
+    this.socket = null;
+    this.buf = Buffer.alloc(0);
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buf = Buffer.concat([this.buf, chunk]);
+    // KNXnet/IP frames carry total_length at offset 4 (common profile).
+    while (true) {
+      if (this.buf.length < 6) return;
+      const totalLength = this.buf.readUInt16BE(4);
+      if (this.buf.length < totalLength) return;
+      const frame = this.buf.subarray(0, totalLength);
+      this.buf = this.buf.subarray(totalLength);
+      this.opt.onFrame(frame);
+    }
+  }
+}

--- a/test/ccm-smoke.test.ts
+++ b/test/ccm-smoke.test.ts
@@ -1,0 +1,11 @@
+import { ccmEncrypt, ccmDecrypt } from "../src/secure/ccm";
+
+test("AES-CCM roundtrip works", () => {
+  const key = Buffer.alloc(16, 0x11);
+  const nonce = Buffer.alloc(12, 0x22);
+  const aad = Buffer.from([0x01, 0x02, 0x03]);
+  const plain = Buffer.from("hello knx secure");
+  const { ciphertext, tag } = ccmEncrypt(key, nonce, aad, plain, 16);
+  const dec = ccmDecrypt(key, nonce, aad, ciphertext, tag, 16);
+  expect(dec.equals(plain)).toBe(true);
+});


### PR DESCRIPTION
# feat(secure): add KNX/IP Secure Tunneling skeleton (TypeScript)

**Scope:** Tunneling Secure only (Routing later).

## Includes
- AES-128-CCM helpers (`src/secure/ccm.ts`)
- Session & counters (`src/secure/session.ts`)
- Secure adapter wrap/unwrap (`src/secure/adapter.ts`)
- Keyring loader (JSON) + manual derive stub (`src/secure/keyring.ts`)
- Frame helpers (stubs) (`src/secure/frame.ts`)
- TCP transport with reassembly (`src/transport/tcp-client.ts`)
- Types (`src/secure/types.ts`)
- Smoke test for CCM (`test/ccm-smoke.test.ts`)

## Why
- Provide a clean, pluggable baseline for KNX/IP Secure Tunneling without touching the existing cEMI/DPT pipeline.
- Keep the critical bits isolated so we can finalize the wrapper/AAD/nonce once we confirm spec details on a target device.

## TODO (before merge)
- [ ] Confirm **Secure Wrapper** byte layout (fields/order/lengths).
- [ ] Confirm **AAD** exact bytes per spec & align builder/parser.
- [ ] Align **Nonce** composition (salt + seq/dir/...).
- [ ] Implement **KDF** for manual derivation (if needed).
- [ ] Add `.knxkeys` **XML** support (normalize to `KeyringObject`).
- [ ] Optional: handshake helper if the device expects a secure hello/exchange.

---

Happy to update this PR after we lock fields from a device pcap.