### PR TITLE
fix: Allow timestamps as Date Input

### DIFF
--- a/src/dptlib/dpt19.ts
+++ b/src/dptlib/dpt19.ts
@@ -26,8 +26,27 @@ const logger = module('DPT19')
 const config: DatapointConfig = {
 	id: 'DPT19',
 	formatAPDU: (value) => {
-		if (typeof value !== 'object' || value.constructor.name !== 'Date') {
-			logger.error('Must supply a Date object')
+		if (value == null) {
+			logger.error('cannot write null value for DPT19')
+			return null
+		}
+		switch (typeof value) {
+			case 'string':
+			case 'number':
+				value = new Date(value)
+				break
+			case 'object':
+				if (value.constructor.name !== 'Date') {
+					logger.error(
+						'Must supply a numeric timestamp, Date or String object for DPT19 DateTime',
+					)
+					return null
+				}
+		}
+		if (isNaN(value.getTime())) {
+			logger.error(
+				'Must supply a numeric timestamp, Date or String object for DPT19 DateTime',
+			)
 			return null
 		}
 		// Sunday is 0 in Javascript, but 7 in KNX.

--- a/src/dptlib/dpt19.ts
+++ b/src/dptlib/dpt19.ts
@@ -36,12 +36,18 @@ const config: DatapointConfig = {
 				value = new Date(value)
 				break
 			case 'object':
-				if (value.constructor.name !== 'Date') {
+				if (!(value instanceof Date)) {
 					logger.error(
 						'Must supply a numeric timestamp, Date or String object for DPT19 DateTime',
 					)
 					return null
 				}
+				break
+			default:
+				logger.error(
+					'Must supply a numeric timestamp, Date or String object for DPT19 DateTime',
+				)
+				return null
 		}
 		if (isNaN(value.getTime())) {
 			logger.error(
@@ -49,10 +55,18 @@ const config: DatapointConfig = {
 			)
 			return null
 		}
+		const year = value.getFullYear()
+		if (year < 1900 || year > 2155) {
+			logger.error(
+				'Year %d is out of DPT19 range (1900-2155)',
+				year,
+			)
+			return null
+		}
 		// Sunday is 0 in Javascript, but 7 in KNX.
 		const day = value.getDay() === 0 ? 7 : value.getDay()
 		const apdu_data = Buffer.alloc(8)
-		apdu_data[0] = value.getFullYear() - 1900
+		apdu_data[0] = year - 1900
 		apdu_data[1] = value.getMonth() + 1
 		apdu_data[2] = value.getDate()
 		apdu_data[3] = (day << 5) + value.getHours()
@@ -61,8 +75,6 @@ const config: DatapointConfig = {
 		apdu_data[6] = 0
 		apdu_data[7] = 0
 		return apdu_data
-
-		return null
 	},
 
 	fromBuffer: (buf) => {
@@ -70,7 +82,7 @@ const config: DatapointConfig = {
 			logger.warn('Buffer should be 8 bytes long, got', buf.length)
 			return null
 		}
-		const d = new Date(
+		return new Date(
 			buf[0] + 1900,
 			buf[1] - 1,
 			buf[2],
@@ -78,8 +90,6 @@ const config: DatapointConfig = {
 			buf[4],
 			buf[5],
 		)
-		return d
-		return null
 	},
 
 	basetype: {


### PR DESCRIPTION
## Summary

Make the DPT19 (8-byte DateTime) `formatAPDU` encoder tolerant of numeric timestamps and ISO strings, and add explicit validation against silent byte overflow.

Previously, `formatAPDU` rejected anything that was not a `Date` object with a hard error. This caused encoding failures in downstream tools that pass a `Date.now()` millisecond timestamp or an ISO string — for example, ioBroker users sending the current time via Blockly hit `"Value 1779117120001 could not be encoded for DPT DPT19.001"`.

The new behavior matches the existing pattern in DPT11 (`dpt11.ts`), which already accepts numeric and string input.

## Changes

- Accept `number` (ms timestamp) and `string` (anything `new Date()` can parse) — both are coerced via `new Date(value)`.
- Use `instanceof Date` instead of `value.constructor.name !== 'Date'` (robust against cross-realm Date objects).
- Add a `default` case in the `switch` so unsupported types (`boolean`, `bigint`, `symbol`) return a clear error instead of crashing on `value.getTime()`.
- Validate `value.getTime()` via `isNaN` to reject `Invalid Date` (e.g. `new Date("foo")`).
- **Validate year range 1900–2155**. DPT19 stores the year in a single byte as `year - 1900`. Without this check, a year of e.g. 2200 was silently truncated (`300 & 0xFF = 44` → decoded as 1944) — a silent data-corruption bug.
- Remove pre-existing dead `return null` statements after `return apdu_data` and in `fromBuffer`.
