### PR TITLE
fix: closeSocket() never resolves on TCP, blocking disconnected event

### DIFF
--- a/src/KNXClient.ts
+++ b/src/KNXClient.ts
@@ -2898,8 +2898,7 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 	 */
 	private async closeSocket() {
 		this.exitProcessingKNXQueueLoop = true // Exits KNX processing queue loop
-		let closeTimeoutRef: NodeJS.Timeout = null
-		const closePromise = new Promise<void>((resolve) => {
+		return new Promise<void>((resolve) => {
 			if (!this._clientSocket) {
 				return resolve()
 			}
@@ -2927,25 +2926,6 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 					`KNXClient: into async closeSocket(): ${error.stack}`,
 				)
 				resolve()
-			}
-		})
-
-		// Belt-and-suspenders: cap closeSocket at 2 s so it can never hang
-		// indefinitely regardless of transport state (e.g. when 'close' fired
-		// before we attached the listener, or the socket was already destroyed).
-		return Promise.race<void>([
-			closePromise,
-			new Promise<void>((resolve) => {
-				closeTimeoutRef = setTimeout(() => {
-					this.sysLogger.warn(
-						`KNXClient: closeSocket timeout after 2000 ms`,
-					)
-					resolve()
-				}, 2000)
-			}),
-		]).finally(() => {
-			if (closeTimeoutRef) {
-				clearTimeout(closeTimeoutRef)
 			}
 		})
 	}
@@ -3034,16 +3014,20 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 		this._clientTunnelSeqNumber = -1
 		this._channelID = null
 
+		// Emit `disconnected` BEFORE awaiting socket teardown so consumers always
+		// learn about the disconnect even if closeSocket() hangs (defensive — the
+		// previous closeSocket() bug never fired this event on TCP transport).
+		this.emit(
+			KNXClientEvents.disconnected,
+			`${this._peerHost}:${this._peerPort} ${_sReason}`,
+		)
+
 		if (this.isSerialTransport()) {
 			await this.closeSerialTransport()
 		} else {
 			await this.closeSocket()
 		}
 
-		this.emit(
-			KNXClientEvents.disconnected,
-			`${this._peerHost}:${this._peerPort} ${_sReason}`,
-		)
 		this.clearToSend = true // 26/12/2021 allow to send
 	}
 

--- a/src/KNXClient.ts
+++ b/src/KNXClient.ts
@@ -2899,8 +2899,9 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 	private async closeSocket() {
 		this.exitProcessingKNXQueueLoop = true // Exits KNX processing queue loop
 		return new Promise<void>((resolve) => {
-			// already closed
-			if (!this._clientSocket) return
+			if (!this._clientSocket) {
+				return resolve()
+			}
 
 			this.socketReady = false
 
@@ -2915,6 +2916,7 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 			try {
 				if (client instanceof TCPSocket) {
 					// use destroy instead of end here to ensure socket is closed
+					client.once('close', cb)
 					client.destroy()
 				} else {
 					;(client as UDPSocket).close(cb)

--- a/src/KNXClient.ts
+++ b/src/KNXClient.ts
@@ -2898,7 +2898,8 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 	 */
 	private async closeSocket() {
 		this.exitProcessingKNXQueueLoop = true // Exits KNX processing queue loop
-		return new Promise<void>((resolve) => {
+		let closeTimeoutRef: NodeJS.Timeout = null
+		const closePromise = new Promise<void>((resolve) => {
 			if (!this._clientSocket) {
 				return resolve()
 			}
@@ -2926,6 +2927,25 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 					`KNXClient: into async closeSocket(): ${error.stack}`,
 				)
 				resolve()
+			}
+		})
+
+		// Belt-and-suspenders: cap closeSocket at 2 s so it can never hang
+		// indefinitely regardless of transport state (e.g. when 'close' fired
+		// before we attached the listener, or the socket was already destroyed).
+		return Promise.race<void>([
+			closePromise,
+			new Promise<void>((resolve) => {
+				closeTimeoutRef = setTimeout(() => {
+					this.sysLogger.warn(
+						`KNXClient: closeSocket timeout after 2000 ms`,
+					)
+					resolve()
+				}, 2000)
+			}),
+		]).finally(() => {
+			if (closeTimeoutRef) {
+				clearTimeout(closeTimeoutRef)
 			}
 		})
 	}

--- a/src/KNXClient.ts
+++ b/src/KNXClient.ts
@@ -2900,7 +2900,8 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 		this.exitProcessingKNXQueueLoop = true // Exits KNX processing queue loop
 		return new Promise<void>((resolve) => {
 			if (!this._clientSocket) {
-				return resolve()
+				resolve()
+				return
 			}
 
 			this.socketReady = false


### PR DESCRIPTION
Two related bugs in `closeSocket()`:

1. The TCP branch calls `client.destroy()` without listening for the `'close'`
   event, so the Promise's `cb` callback is never invoked. `net.Socket.destroy()`
   is synchronous and takes no callback (unlike `dgram.Socket.close(cb)` used in
   the UDP branch). Result: the Promise stays pending forever.

2. The early-return guard `if (!this._clientSocket) return` inside the Promise
   executor returns without calling `resolve()`, also leaving the Promise pending.

Because `setDisconnected()` does `await this.closeSocket()` before emitting
`KNXClientEvents.disconnected`, the `disconnected` event is never emitted on
TCP transport — neither after a heartbeat-death (`runHeartbeat` declares
`Connection dead with ...`) nor after a user-initiated `Disconnect()` with
`_channelID === null`.

Real-world impact (production log, TunnelTCP + KNX Secure):

  20:24:34  KNXClient: getConnectionStatus timeout attempt 3/3
  20:24:34  Error: Connection dead with 192.168.178.25:3671
            at KNXClient.runHeartbeat (KNXClient.ts:3043:21)
  [no `disconnected` event ever fires — silence for 25 minutes]
  20:49:48  Failed to write to 0/1/58: The socket is not connected.

The TCP `'close'` listener installed by `initTcpSocket()` does NOT rescue this
path because it calls `setDisconnected()` again, which is gated by
`_connectionState !== DISCONNECTED` — but the first call already set the state
to DISCONNECTED before awaiting `closeSocket()`.

Fix: for TCP, attach a one-shot `'close'` handler that resolves the Promise
before calling `destroy()`. Plus call `resolve()` on the early-return path.