### PR TITLE
feat(secure)!: validate KNX Secure receive path and release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [6.0.0](https://github.com/Supergiovane/KNXUltimate/compare/v5.5.9...v6.0.0) (2026-06-30)
+
+### ⚠ BREAKING CHANGES
+
+* **secure:** the KNX/IP Secure and Data Secure **receive path is now validated**. Frames that fail cryptographic authentication or freshness checks are **silently dropped instead of being emitted** as `indication` events. Code that previously (even if unintentionally) acted on forged, tampered or replayed secure telegrams will no longer receive them. This is a security fix, but it changes observable behaviour, hence the major version bump.
+* **secure:** inside an established KNX/IP Secure session, **plaintext KNX/IP frames are now dropped** (only `SecureWrapper` frames and the initial `SESSION_RESPONSE` are accepted). A previously tolerated plaintext `CONNECT_RESPONSE` fallback is no longer honoured.
+* **secure:** the Data Secure sender sequence (48-bit) **no longer wraps around**. When the maximum value is reached, secure sending throws instead of silently reusing a sequence number; new key material is required to continue.
+
+### Features
+
+* **secure:** verify the `SESSION_RESPONSE` device-authentication MAC during the unicast handshake before trusting the server's public key; a forged response now aborts the handshake.
+* **secure:** verify the `SecureWrapper` MAC and enforce a strictly increasing wrapper sequence per session (anti-replay); invalid or replayed wrappers are dropped while keeping the session alive.
+* **secure:** enforce Data Secure per-source anti-replay using the 48-bit sender sequence and reject telegrams with an invalid MAC.
+* **secure:** new optional `secureTunnelConfig.deviceAuthenticationPassword` to supply the device authentication password in manual mode (no keyring). When a keyring is provided it is taken from the keyring automatically.
+
 ## [5.5.9](https://github.com/Supergiovane/KNXUltimate/compare/v5.5.8...v5.5.9) (2026-06-10)
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,34 @@ This is the official engine of Node-Red's node [node-red-contrib-knx-ultimate](h
 </p>
 
 
+## ⚠️ BREAKING CHANGES IN v6.0.0 (KNX Secure validation)
+
+> **If you use KNX/IP Secure or Data Secure, please read this before upgrading.**
+>
+> Version 6.0.0 hardens the **receive path** of the secure stack. The library now
+> cryptographically validates incoming secure traffic and **drops frames that fail
+> authentication or freshness checks instead of emitting them**:
+>
+> - The `SESSION_RESPONSE` device-authentication MAC is verified during the unicast
+>   handshake; a forged response now aborts the connection.
+> - `SecureWrapper` frames are MAC-verified and protected against replay (the wrapper
+>   sequence must strictly increase). Invalid/replayed wrappers are dropped.
+> - Data Secure group telegrams are MAC-verified and protected against replay per
+>   source address. Forged, tampered or replayed telegrams are **no longer delivered**
+>   as `indication` events.
+> - Inside an established secure session, **plaintext KNX/IP frames are dropped** (only
+>   `SecureWrapper` frames are accepted).
+> - The Data Secure **sender sequence no longer wraps**: once the 48-bit maximum is
+>   reached, sending throws and new key material is required.
+>
+> **What you may need to do:**
+> - In **manual** (no keyring) secure configurations, set the new
+>   `secureTunnelConfig.deviceAuthenticationPassword` so the `SESSION_RESPONSE` MAC can
+>   be verified. When a keyring is provided, this value is taken from the keyring
+>   automatically and no change is needed.
+> - If your application relied (even unintentionally) on receiving unvalidated secure
+>   telegrams, be aware that those frames are now filtered out.
+
 ## CHANGELOG
 
 - [Changelog](https://github.com/Supergiovane/knxultimate/blob/master/CHANGELOG.md)

--- a/documents/Secure Test.knxkeys
+++ b/documents/Secure Test.knxkeys
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Keyring Project="Secure Test" CreatedBy="6.3.1" Created="2025-09-14T07:29:12" Signature="ngBEAf0L6VI5psu6UfrMQg==" xmlns="http://knx.org/xml/keyring/1">
-  <Backbone MulticastAddress="224.0.23.12" Latency="2000" Key="ewwYjB9lQUy2cD1xCQN0Sg==" />
-  <Interface IndividualAddress="1.1.252" Type="Tunneling" Host="1.1.0" UserID="5" Password="pknkNPOHPY643f3BuCPnrMjiE0qPqnlkq5HpZovL3D4=" Authentication="xvciNXh1/NDGrlvTW3EaFCKa2Ry8qWNcT56FLNmt0eA=">
+<Keyring Project="Secure Test" CreatedBy="6.3.1" Created="2025-10-08T13:51:33" Signature="r0MgUljDyqorRnoQil8YPA==" xmlns="http://knx.org/xml/keyring/1">
+  <Backbone MulticastAddress="224.0.23.12" Latency="2000" Key="J3Hvtw+wlouiSaSk6ib33g==" />
+  <Interface IndividualAddress="1.1.252" Type="Tunneling" Host="1.1.0" UserID="5" Password="00XuHQwX6tmR1nRolvD6KSKWJ9O7jLMIPSysHNf2lYA=" Authentication="JXTl7Coi87kcu2KFmDmZ7AHILWQWa7WoVGK1EdPr3Bk=">
     <Group Address="2305" Senders="1.1.1 1.1.253 1.1.254 1.1.255" />
     <Group Address="2306" Senders="1.1.1 1.1.253 1.1.254 1.1.255" />
   </Interface>
-  <Interface IndividualAddress="1.1.253" Type="Tunneling" Host="1.1.0" UserID="4" Password="50nItXfHb4D79FBRLCE1fLXy/EXoOrAqtw3UZLnkaAU=" Authentication="qLqyYytrQwVXbl0cIlyim8uuTyhIw1UOVKX080F2kag=">
+  <Interface IndividualAddress="1.1.253" Type="Tunneling" Host="1.1.0" UserID="4" Password="U2T9zgUP82rPcs89qcMkbej/9GM5ala5wj4yn+UX2VA=" Authentication="a3KRj1KPhnSDxa8Liu3W9AXCPsZ+xnBKEJgxDfzIW4E=">
     <Group Address="2305" Senders="1.1.1 1.1.252 1.1.254 1.1.255" />
     <Group Address="2306" Senders="1.1.1 1.1.252 1.1.254 1.1.255" />
   </Interface>
-  <Interface IndividualAddress="1.1.254" Type="Tunneling" Host="1.1.0" UserID="3" Password="Ggn6Psk+qPA8KHKYcq4GsI6vhR8Y99C2KP2Lfcp5YUg=" Authentication="1hwb7qmALZf05FvjF/5LlDEgUJmtvljVx1OL0jk1CYs=">
+  <Interface IndividualAddress="1.1.254" Type="Tunneling" Host="1.1.0" UserID="3" Password="wVCJGcheIOWse2+S5gGLAF2/NWaLy635b2FBkd1L0mA=" Authentication="u+VOg8ZSbYLfSFYJB2n8Ss808x+dDwY8fUHeRdsu7OQ=">
     <Group Address="2305" Senders="1.1.1 1.1.252 1.1.253 1.1.255" />
     <Group Address="2306" Senders="1.1.1 1.1.252 1.1.253 1.1.255" />
   </Interface>
-  <Interface IndividualAddress="1.1.255" Type="Tunneling" Host="1.1.0" UserID="2" Password="KkmarKuV2DEerN0kK/nCJDEb0Ee5lTpIyxkTehP/KyA=" Authentication="9KMIf3MAV1ptU5YbRDbEyiL0CdN+j+YqwMwFGvkBPA4=">
+  <Interface IndividualAddress="1.1.255" Type="Tunneling" Host="1.1.0" UserID="2" Password="9e2tYEXNELFEvbpZ1yJyRaGdtXwN2k7BJsjRf5/xyUI=" Authentication="k+KhcnIHbUEuQWticPySIpXVpoqvazhoaFxK7+e7nyI=">
     <Group Address="2305" Senders="1.1.1 1.1.252 1.1.253 1.1.254" />
     <Group Address="2306" Senders="1.1.1 1.1.252 1.1.253 1.1.254" />
   </Interface>
   <GroupAddresses>
-    <Group Address="2305" Key="38sYpw2b0rJ2NV3Ra/CMkg==" />
-    <Group Address="2306" Key="nTwvAMyTvEFvmv3kklJp4w==" />
+    <Group Address="2305" Key="meCzTJbV3QN0/dSmin9tCg==" />
+    <Group Address="2306" Key="j2qYK1rPZemSHKQ8BLHiFQ==" />
   </GroupAddresses>
   <Devices>
-    <Device IndividualAddress="1.1.0" ToolKey="52c9dpyjrtNvKYoHUTYocA==" ManagementPassword="ZDhaXUXq8QNpMppkxiXL0hbDpD+FvSH3Um8YctQhHD4=" Authentication="hcRZsX2F9dj5zzTk3Gyt4+1UHMdgHI5tqoANctmEBIw=" SequenceNumber="242724394462" FDSK="rH5OzcTOosTVIG5T09wVoA==" SerialNumber="00A207164012" />
-    <Device IndividualAddress="1.1.1" ToolKey="dkVu3fd/C7IkrrIeXNyMtA==" SequenceNumber="240662586791" FDSK="CVwA/R5Jx7O1LPTFRwVP6w==" SerialNumber="000A28A90D19" />
+    <Device IndividualAddress="1.1.0" ToolKey="DfcQadqkD1fzUIes8MnN7Q==" ManagementPassword="iA7f7v4vZ94mZULrcLmpecTAkZMDMw/lpcHkyGtiPcM=" Authentication="F5Bwb6GRcFljGHCE7U54njwAbj9oLvkiNDEw/ErcotM=" SequenceNumber="0" FDSK="Fum47oNWFLf4KYDzToPmBA==" SerialNumber="00A207164012" />
+    <Device IndividualAddress="1.1.1" ToolKey="lX/0uh7OrOduPRepnUNFGw==" SequenceNumber="240662587667" FDSK="dE4/ygckPiqJx2xksMhXVg==" SerialNumber="000A28A90D19" />
   </Devices>
 </Keyring>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knxultimate",
-  "version": "5.5.9",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "knxultimate",
-      "version": "5.5.9",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "binary-parser": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knxultimate",
   "description": "KNX protocol implementation for Node.js, support KNX/IP Tunneling/Routing, KNX/IP Secure and Data Secure, FT1.2/KBerry TP plain KNXas well as full secure KNX stack. This is the ENGINE of Node-Red KNX-Ultimate node. Go check it!",
-  "version": "5.5.9",
+  "version": "6.0.0",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "files": [

--- a/src/KNXClient.ts
+++ b/src/KNXClient.ts
@@ -52,6 +52,7 @@ import {
 	calculateMessageAuthenticationCodeCBC,
 	encryptDataCtr,
 	decryptCtr,
+	deriveDeviceAuthenticationPassword,
 } from './secure/security_primitives'
 import {
 	SCF_ENCRYPTION_S_A_DATA,
@@ -69,6 +70,7 @@ import {
 	KNXIP_HDR_TUNNELING_ACK,
 	KNXIP_HDR_TUNNELING_CONNECT_REQUEST,
 	KNXIP_HDR_SECURE_SESSION_REQUEST,
+	KNXIP_HDR_SECURE_SESSION_RESPONSE,
 	KNXIP_HDR_SECURE_SESSION_AUTHENTICATE,
 	DATA_SECURE_CTR_SUFFIX,
 	AUTH_CTR_IV,
@@ -114,6 +116,14 @@ export interface SecureConfig {
 	knxkeys_password?: string
 	tunnelUserPassword?: string
 	tunnelUserId?: number
+	/**
+	 * Device authentication password of the secure gateway/interface. Used to
+	 * verify the SESSION_RESPONSE MAC during the KNX/IP Secure unicast handshake.
+	 * When a keyring is provided this is taken from the keyring automatically; set
+	 * it explicitly only in manual mode (no keyring). Without it, the
+	 * SESSION_RESPONSE MAC cannot be verified.
+	 */
+	deviceAuthenticationPassword?: string
 }
 
 export enum ConncetionState {
@@ -325,6 +335,10 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 
 	private _secureWrapperSeq: number = 0 // 6-byte counter (we store as number increment)
 
+	// Highest wrapper sequence accepted from the peer in the current session.
+	// -1 means "nothing received yet". Used to reject replayed/old SecureWrapper frames.
+	private _secureRxWrapperSeq: number = -1
+
 	private _secureTunnelSeq: number = 0 // 1-byte seq in tunneling connection header
 
 	private _securePrivateKey?: crypto.KeyObject
@@ -338,6 +352,15 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 	private _secureGroupKeys: Map<number, Buffer> = new Map()
 
 	private _secureSendSeq48: bigint = 0n
+
+	// Per-source last accepted Data Secure sender sequence (48-bit), keyed by source
+	// individual address. Used to reject replayed/old secure group telegrams.
+	private _secureDataRecvSeq: Map<number, bigint> = new Map()
+
+	// Device authentication code (16-byte derived key) used to verify the
+	// SESSION_RESPONSE MAC. Undefined when no device authentication password is
+	// available (e.g. manual config without it).
+	private _secureDeviceAuthCode?: Buffer
 
 	private _secureSerial: Buffer = Buffer.from('000000000000', 'hex')
 
@@ -809,12 +832,13 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 						payload,
 						1,
 					)
-					this.ensurePlainCEMI(cemi)
-					this.emit(
-						KNXClientEvents.indication,
-						new KNXRoutingIndication(cemi),
-						false,
-					)
+					if (this.ensurePlainCEMI(cemi)) {
+						this.emit(
+							KNXClientEvents.indication,
+							new KNXRoutingIndication(cemi),
+							false,
+						)
+					}
 					break
 				}
 				case CEMIConstants.L_DATA_CON: {
@@ -2641,6 +2665,8 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 			this._secureSerial = Buffer.from('000000000000', 'hex')
 			this._secureAssignedIa = 0
 			this._secureWrapperSeq = 0
+			this._secureRxWrapperSeq = -1
+			this._secureDataRecvSeq.clear()
 			this._secureSearchProbed.clear()
 
 			cfg.tunnelInterfaceIndividualAddress = ia
@@ -3444,13 +3470,15 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 					knxTunnelingRequest.cEMIMessage.msgCode ===
 					CEMIConstants.L_DATA_IND
 				) {
-					// Ensure plain KNX (decrypt Data Secure if needed) and emit full telegram
-					this.ensurePlainCEMI(knxTunnelingRequest.cEMIMessage)
-					this.emit(
-						KNXClientEvents.indication,
-						knxTunnelingRequest as any,
-						false,
-					)
+					// Ensure plain KNX (decrypt Data Secure if needed) and emit full
+					// telegram, unless it failed secure validation (drop forged/replayed).
+					if (this.ensurePlainCEMI(knxTunnelingRequest.cEMIMessage)) {
+						this.emit(
+							KNXClientEvents.indication,
+							knxTunnelingRequest as any,
+							false,
+						)
+					}
 				} else if (
 					knxTunnelingRequest.cEMIMessage.msgCode ===
 					CEMIConstants.L_DATA_CON
@@ -3513,13 +3541,15 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 					knxRoutingInd.cEMIMessage.msgCode ===
 					CEMIConstants.L_DATA_IND
 				) {
-					// Ensure plain KNX (decrypt Data Secure if needed) and emit full telegram
-					this.ensurePlainCEMI(knxRoutingInd.cEMIMessage)
-					this.emit(
-						KNXClientEvents.indication,
-						knxRoutingInd as any,
-						false,
-					)
+					// Ensure plain KNX (decrypt Data Secure if needed) and emit full
+					// telegram, unless it failed secure validation (drop forged/replayed).
+					if (this.ensurePlainCEMI(knxRoutingInd.cEMIMessage)) {
+						this.emit(
+							KNXClientEvents.indication,
+							knxRoutingInd as any,
+							false,
+						)
+					}
 				} else if (
 					knxRoutingInd.cEMIMessage.msgCode ===
 					CEMIConstants.L_DATA_CON
@@ -3689,6 +3719,25 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 				} catch {}
 			}
 
+			// Derive the device authentication code used to verify the
+			// SESSION_RESPONSE MAC during the unicast handshake.
+			const deviceAuthPwd = (
+				dev?.decryptedAuthentication ||
+				iface?.decryptedAuthentication ||
+				cfg.deviceAuthenticationPassword ||
+				''
+			).trim()
+			if (deviceAuthPwd) {
+				try {
+					this._secureDeviceAuthCode =
+						deriveDeviceAuthenticationPassword(deviceAuthPwd)
+				} catch (e) {
+					this.sysLogger.warn(
+						`Secure: cannot derive device authentication code: ${(e as Error).message}`,
+					)
+				}
+			}
+
 			// Load Backbone key for secure multicast routing (if present)
 			try {
 				const backbones = kr.getBackbones()
@@ -3734,6 +3783,18 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 			'sha256',
 		)
 		this._secureSerial = Buffer.from('000000000000', 'hex')
+		// Optional device authentication code for SESSION_RESPONSE MAC verification.
+		const manualDeviceAuthPwd = cfg.deviceAuthenticationPassword?.trim()
+		if (manualDeviceAuthPwd) {
+			try {
+				this._secureDeviceAuthCode =
+					deriveDeviceAuthenticationPassword(manualDeviceAuthPwd)
+			} catch (e) {
+				this.sysLogger.warn(
+					`Secure: cannot derive device authentication code: ${(e as Error).message}`,
+				)
+			}
+		}
 		try {
 			if (this.isLevelEnabled('info')) {
 				this.sysLogger.info(
@@ -3756,6 +3817,11 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 		}) as Buffer
 		// Last 32 bytes contain raw public key
 		this._securePublicKey = exported.subarray(exported.length - 32)
+
+		// Fresh session: reset receive-side freshness state.
+		this._secureWrapperSeq = 0
+		this._secureRxWrapperSeq = -1
+		this._secureDataRecvSeq.clear()
 
 		this._secureHandshakeState = 'session'
 		// Send SESSION_REQUEST immediately
@@ -3801,6 +3867,32 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 				this._secureSessionId = frame.readUInt16BE(6)
 				const serverPublicKey = frame.subarray(8, 40)
 
+				// Verify the SESSION_RESPONSE device-authentication MAC before
+				// trusting the server public key. A forged response without a
+				// valid MAC must abort the handshake.
+				if (this._secureDeviceAuthCode) {
+					if (!this.secureVerifySessionResponse(frame)) {
+						const err = new Error(
+							'SESSION_RESPONSE device-authentication MAC verification failed',
+						)
+						this.emit(KNXClientEvents.error, err)
+						this._secureHandshakeState = undefined
+						this.setDisconnected(err.message).catch(() => {})
+						return
+					}
+					try {
+						this.sysLogger.debug(
+							`[${getTimestamp()}] SESSION_RESPONSE MAC verified`,
+						)
+					} catch {}
+				} else {
+					try {
+						this.sysLogger.warn(
+							`[${getTimestamp()}] SESSION_RESPONSE MAC NOT verified: no device authentication code available (set secureTunnelConfig.deviceAuthenticationPassword or use a keyring).`,
+						)
+					} catch {}
+				}
+
 				// Compute session key
 				const X25519_SPKI_PREFIX_DER = Buffer.from(
 					'302a300506032b656e032100',
@@ -3841,7 +3933,19 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 					)
 				}, SECURE_AUTH_TIMEOUT_MS)
 			} else if (type === KNXIP.SECURE_WRAPPER) {
-				const inner = this.secureDecrypt(frame)
+				let inner: Buffer
+				try {
+					inner = this.secureDecrypt(frame)
+				} catch (e) {
+					// Drop replayed, MAC-invalid or malformed wrappers and keep
+					// the session alive instead of acting on untrusted data.
+					try {
+						this.sysLogger.warn(
+							`[${getTimestamp()}] Dropping SecureWrapper: ${(e as Error).message}`,
+						)
+					} catch {}
+					continue
+				}
 				const innerType = inner.readUInt16BE(2)
 				if (
 					innerType === KNXIP.SECURE_SESSION_STATUS &&
@@ -3963,28 +4067,18 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 					} as any
 					this.processInboundMessage(inner, rinfo)
 				}
-			} else if (
-				type === KNXIP.TUNNELING_CONNECT_RESPONSE &&
-				this._secureHandshakeState === 'connect'
-			) {
-				// Plain fallback CONNECT_RESPONSE (rare)
-				if (this._secureHandshakeConnectTimer) {
-					clearTimeout(this._secureHandshakeConnectTimer)
-					this._secureHandshakeConnectTimer = undefined
-				}
-				const ch = frame[6]
-				const status = frame[7]
-				if (status === 0) {
-					this._channelID = ch
-					this._connectionState = ConncetionState.CONNECTED
-					this._numFailedTelegramACK = 0
-					this.clearToSend = true
-					this.emit(KNXClientEvents.connected, this._options)
-					this.startHeartBeat()
-					this.handleKNXQueue()
-				}
+			} else if (this._options.isSecureKNXEnabled) {
+				// Inside a KNX/IP Secure session only SecureWrapper frames (and the
+				// initial plaintext SESSION_RESPONSE handled above) are legitimate.
+				// Any other plaintext KNX/IP frame is dropped: a CONNECT_RESPONSE or
+				// tunnelling frame must arrive wrapped once the session is up.
+				try {
+					this.sysLogger.warn(
+						`[${getTimestamp()}] Dropping plaintext frame type=0x${type.toString(16)} inside secure session`,
+					)
+				} catch {}
 			} else {
-				// Other plaintext frames: route to parser if relevant
+				// Plain (non-secure) TCP tunnelling: route to parser as usual.
 				const rinfo: RemoteInfo = {
 					address: this._peerHost,
 					port: this._peerPort,
@@ -4415,23 +4509,63 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 	private secureDecrypt(frame: Buffer): Buffer {
 		if (!this._secureSessionKey)
 			throw new Error('Secure session not established')
+		if (frame.length < SECURE_WRAPPER_OVERHEAD)
+			throw new Error('SecureWrapper frame too short')
+		const sessionId = frame.readUInt16BE(6)
 		const seq = frame.subarray(8, 14)
 		const serial = frame.subarray(14, 20)
 		const tag = frame.subarray(20, 22)
-		const data = frame.subarray(22, frame.length - 16)
+		const encData = frame.subarray(22, frame.length - MAC_LEN_FULL)
+		const encMac = frame.subarray(frame.length - MAC_LEN_FULL)
 		const ctr0 = Buffer.concat([
 			seq,
 			serial,
 			tag,
 			SECURE_WRAPPER_MAC_SUFFIX,
 		])
-		const dec = crypto.createDecipheriv(
-			'aes-128-ctr',
+		const [data, macTr] = decryptCtr(
 			this._secureSessionKey,
 			ctr0,
+			encMac,
+			encData,
 		)
-		dec.update(frame.subarray(frame.length - MAC_LEN_FULL))
-		return dec.update(data)
+
+		// Verify the wrapper MAC (CBC-MAC over header + session id + plaintext).
+		// A tampered or forged wrapper produces a mismatching MAC and is rejected.
+		const additionalData = Buffer.concat([
+			frame.subarray(0, 6), // KNX/IP header incl. total length
+			frame.subarray(6, 8), // secure session id
+		])
+		const block0 = Buffer.concat([
+			seq,
+			serial,
+			tag,
+			Buffer.from([(data.length >> 8) & 0xff, data.length & 0xff]),
+		])
+		const macCbc = calculateMessageAuthenticationCodeCBC(
+			this._secureSessionKey,
+			additionalData,
+			data,
+			block0,
+		)
+		if (!macCbc.equals(macTr)) {
+			throw new Error('SecureWrapper MAC verification failed')
+		}
+
+		// Freshness / anti-replay: the wrapper sequence must strictly increase
+		// within a session. Reject replayed or out-of-order wrappers.
+		const seqNum = seq.readUIntBE(0, SECURE_SEQ_LEN)
+		if (
+			this._secureRxWrapperSeq >= 0 &&
+			seqNum <= this._secureRxWrapperSeq
+		) {
+			throw new Error(
+				`SecureWrapper replay detected (seq=${seqNum} last=${this._secureRxWrapperSeq} sid=${sessionId})`,
+			)
+		}
+		this._secureRxWrapperSeq = seqNum
+
+		return data
 	}
 
 	private secureBuildSessionRequest(): Buffer {
@@ -4444,6 +4578,46 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 			HPAI_CONTROL_ENDPOINT_EMPTY,
 			this._securePublicKey!,
 		])
+	}
+
+	// Verify the SESSION_RESPONSE MAC using the device authentication code.
+	// The MAC authenticates the server's public value (as X xor Y) and the
+	// secure session id; a forged response cannot produce a valid MAC.
+	private secureVerifySessionResponse(frame: Buffer): boolean {
+		if (!this._secureDeviceAuthCode || !this._securePublicKey) return false
+		if (frame.length < 8 + PUBLIC_KEY_LEN + MAC_LEN_FULL) return false
+		const sessionId = frame.readUInt16BE(6)
+		const serverPublicKey = frame.subarray(8, 8 + PUBLIC_KEY_LEN)
+		const receivedMac = frame.subarray(
+			8 + PUBLIC_KEY_LEN,
+			8 + PUBLIC_KEY_LEN + MAC_LEN_FULL,
+		)
+		const xor = Buffer.alloc(PUBLIC_KEY_LEN)
+		for (let i = 0; i < PUBLIC_KEY_LEN; i++)
+			xor[i] = this._securePublicKey[i] ^ serverPublicKey[i]
+		const totalLen = frame.readUInt16BE(4)
+		const additionalData = Buffer.concat([
+			KNXIP_HDR_SECURE_SESSION_RESPONSE,
+			Buffer.from([(totalLen >> 8) & 0xff, totalLen & 0xff]),
+			Buffer.from([(sessionId >> 8) & 0xff, sessionId & 0xff]),
+			xor,
+		])
+		const block0 = Buffer.alloc(AES_BLOCK_LEN, 0)
+		const macCbc = calculateMessageAuthenticationCodeCBC(
+			this._secureDeviceAuthCode,
+			additionalData,
+			Buffer.alloc(0),
+			block0,
+		)
+		// The MAC carried in the frame is CTR-encrypted with the device auth
+		// code (Ctr0 = AUTH_CTR_IV); decrypt it and compare with the CBC-MAC.
+		const ctr = crypto.createDecipheriv(
+			'aes-128-ctr',
+			this._secureDeviceAuthCode,
+			AUTH_CTR_IV,
+		)
+		const macTr = ctr.update(receivedMac)
+		return macCbc.equals(macTr)
 	}
 
 	private secureBuildSessionAuthenticate(serverPublicKey: Buffer): Buffer {
@@ -4525,9 +4699,18 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 				`No Data Secure key for GA ${this.secureFormatGroupAddress(groupAddr)}`,
 			)
 		const seq = Buffer.alloc(SECURE_SEQ_LEN)
-		const current = this._secureSendSeq48 & 0xffffffffffffn
+		// The Data Secure sender sequence is 48-bit and MUST NOT wrap: once the
+		// maximum value has been used, secure sending has to stop until the key
+		// material is renewed. Refuse to send rather than reuse a sequence.
+		const SECURE_SEND_SEQ_MAX = 0xffffffffffffn
+		if (this._secureSendSeq48 > SECURE_SEND_SEQ_MAX) {
+			throw new Error(
+				'Data Secure sender sequence exhausted (48-bit maximum reached); refusing to send. New key material is required.',
+			)
+		}
+		const current = this._secureSendSeq48
 		seq.writeUIntBE(Number(current), 0, 6)
-		this._secureSendSeq48 = (this._secureSendSeq48 + 1n) & 0xffffffffffffn
+		this._secureSendSeq48 += 1n
 		const addrFields = Buffer.from([
 			(srcIa >> 8) & 0xff,
 			srcIa & 0xff,
@@ -4722,32 +4905,35 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 		}
 	}
 
-	// Decrypt incoming Data Secure NPDU in-place if applicable
-	private maybeDecryptDataSecure(cemi: any) {
+	// Decrypt incoming Data Secure NPDU in-place if applicable.
+	// Returns false when the telegram is a Data Secure APDU that failed
+	// authentication (bad MAC) or freshness (replay) and must be dropped;
+	// returns true otherwise (decrypted in place, or nothing to do).
+	private maybeDecryptDataSecure(cemi: any): boolean {
 		try {
-			if (!this._options.isSecureKNXEnabled) return
+			if (!this._options.isSecureKNXEnabled) return true
 			if (!this._secureGroupKeys || this._secureGroupKeys.size === 0)
-				return
+				return true
 			const npdu = cemi?.npdu
-			if (!npdu) return
+			if (!npdu) return true
 			if (
 				(npdu.tpci & 0xff) !== APCI_SEC.HIGH ||
 				(npdu.apci & 0xff) !== APCI_SEC.LOW
 			)
-				return
+				return true
 			const dst = cemi?.dstAddress?.get?.() as number
 			const src = cemi?.srcAddress?.get?.() as number
-			if (typeof dst !== 'number' || typeof src !== 'number') return
+			if (typeof dst !== 'number' || typeof src !== 'number') return true
 			const key = this._secureGroupKeys.get(dst)
-			if (!key) return
+			if (!key) return true
 			const ctrlBuf: Buffer = cemi?.control?.toBuffer?.()
-			if (!Buffer.isBuffer(ctrlBuf) || ctrlBuf.length < 2) return
+			if (!Buffer.isBuffer(ctrlBuf) || ctrlBuf.length < 2) return true
 			const flags2 = ctrlBuf[1] & SEC_CEMI.CTRL2_RELEVANT_MASK
 
 			const dataPart: Buffer = npdu.dataBuffer
 				? npdu.dataBuffer.value
 				: Buffer.alloc(0)
-			if (dataPart.length < 1 + SECURE_SEQ_LEN + 4) return
+			if (dataPart.length < 1 + SECURE_SEQ_LEN + 4) return true
 			const scf = dataPart[0]
 			const seq = dataPart.subarray(1, 1 + SECURE_SEQ_LEN)
 			const encPayloadAndMac = dataPart.subarray(1 + SECURE_SEQ_LEN)
@@ -4791,7 +4977,31 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 				decPayload,
 				block0,
 			).subarray(0, MAC_LEN_SHORT)
-			if (!macCbc.equals(macTr)) return
+			if (!macCbc.equals(macTr)) {
+				try {
+					this.sysLogger.warn(
+						`[${getTimestamp()}] Dropping Data Secure telegram with invalid MAC src=${src} dst=${dst}`,
+					)
+				} catch {}
+				return false
+			}
+
+			// Freshness / anti-replay: the sender sequence is a 48-bit counter that
+			// must strictly increase per source. Reject replays (including seq=0
+			// frames seen after a sender wrap) so a captured telegram cannot be
+			// re-injected and acted upon.
+			const seqNum = seq.readUIntBE(0, SECURE_SEQ_LEN)
+			const lastSeq = this._secureDataRecvSeq.get(src)
+			if (lastSeq !== undefined && BigInt(seqNum) <= lastSeq) {
+				try {
+					this.sysLogger.warn(
+						`[${getTimestamp()}] Dropping replayed Data Secure telegram src=${src} dst=${dst} seq=${seqNum} last=${lastSeq}`,
+					)
+				} catch {}
+				return false
+			}
+			this._secureDataRecvSeq.set(src, BigInt(seqNum))
+
 			// Rebuild plain NPDU: TPCI=0x00, APCI=second byte, data after first 2 bytes
 			npdu.tpci = TPCI_DATA
 			if (decPayload.length >= 2) {
@@ -4804,20 +5014,25 @@ export default class KNXClient extends TypedEventEmitter<KNXClientEventCallbacks
 				npdu.apci = 0
 				npdu.data = null
 			}
+			return true
 		} catch (e) {
 			this.sysLogger.error(
 				`maybeDecryptDataSecure error: ${(e as Error).message}`,
 			)
+			return true
 		}
 	}
 
-	// Ensure the provided cEMI message is in plain KNX form before emitting
+	// Ensure the provided cEMI message is in plain KNX form before emitting.
 	// If Data Secure is detected and keys are available, decrypts it in-place.
-	private ensurePlainCEMI<T extends CEMIMessage>(cemi: T): T {
+	// Returns false when the telegram failed secure validation (bad MAC or
+	// replay) and must NOT be delivered to the application.
+	private ensurePlainCEMI<T extends CEMIMessage>(cemi: T): boolean {
 		try {
-			this.maybeDecryptDataSecure(cemi as any)
-		} catch {}
-		return cemi
+			return this.maybeDecryptDataSecure(cemi as any)
+		} catch {
+			return true
+		}
 	}
 
 	private sendDescriptionRequestMessage() {

--- a/src/secure/secure_knx_constants.ts
+++ b/src/secure/secure_knx_constants.ts
@@ -64,6 +64,7 @@ export const KNXIP_HDR_TUNNELING_CONNECT_REQUEST = Buffer.from(
 	'hex',
 )
 export const KNXIP_HDR_SECURE_SESSION_REQUEST = Buffer.from('06100951', 'hex')
+export const KNXIP_HDR_SECURE_SESSION_RESPONSE = Buffer.from('06100952', 'hex')
 export const KNXIP_HDR_SECURE_SESSION_AUTHENTICATE = Buffer.from(
 	'06100953',
 	'hex',

--- a/test/secure/MockSecureGateway.ts
+++ b/test/secure/MockSecureGateway.ts
@@ -25,6 +25,9 @@ import {
 	APCI_SEC,
 	TPCI_DATA,
 	DATA_SECURE_CTR_SUFFIX,
+	AUTH_CTR_IV,
+	AES_BLOCK_LEN,
+	KNXIP_HDR_SECURE_SESSION_RESPONSE,
 	CEMI as SEC_CEMI,
 } from '../../src/secure/secure_knx_constants'
 import {
@@ -70,6 +73,9 @@ type SecureGatewayOptions = {
 	tunnelAssignedIndividualAddress?: string
 	groupKeys?: Record<string, Buffer>
 	initialSendSeq48?: bigint
+	/** 16-byte derived device authentication code; when set the gateway emits a
+	 * SESSION_RESPONSE MAC so clients can verify the handshake. */
+	deviceAuthCode?: Buffer
 }
 
 const X25519_SPKI_PREFIX_DER = Buffer.from('302a300506032b656e032100', 'hex')
@@ -115,6 +121,8 @@ export class MockSecureGateway extends TypedEventEmitter<GatewayEvents> {
 
 	private readonly serverPublicKeyRaw: Buffer
 
+	private readonly deviceAuthCode: Buffer | null
+
 	constructor(options: SecureGatewayOptions = {}) {
 		super()
 		this.host = options.host ?? '127.0.0.1'
@@ -139,6 +147,10 @@ export class MockSecureGateway extends TypedEventEmitter<GatewayEvents> {
 		}
 		this.sendSeq48Start = options.initialSendSeq48 ?? BigInt(Date.now())
 		this.sendSeq48 = this.sendSeq48Start
+		this.deviceAuthCode =
+			options.deviceAuthCode && options.deviceAuthCode.length >= 16
+				? Buffer.from(options.deviceAuthCode.subarray(0, 16))
+				: null
 		const keyPair = crypto.generateKeyPairSync('x25519')
 		this.serverPrivateKey = keyPair.privateKey
 		const exported = keyPair.publicKey.export({
@@ -198,6 +210,23 @@ export class MockSecureGateway extends TypedEventEmitter<GatewayEvents> {
 		) {
 			throw new Error('Secure session not established')
 		}
+		const { inner } = this.buildSecureGroupWriteInner(groupAddress, value)
+		this.socket.write(this.wrapFrame(inner))
+	}
+
+	// ===== Test attack helpers =====
+
+	/**
+	 * Build the inner KNX/IP tunnelling frame for a secure group write. When
+	 * forceSeq is provided the Data Secure sender sequence is forced to that
+	 * value (used to craft Data Secure replays without advancing the real
+	 * counter). Returns the inner frame and the 48-bit sequence used.
+	 */
+	buildSecureGroupWriteInner(
+		groupAddress: string,
+		value: boolean,
+		forceSeq?: bigint,
+	): { inner: Buffer; seq48: bigint } {
 		const dst = new GroupAddress(groupAddress).raw
 		const key = this.groupKeys.get(dst)
 		if (!key) {
@@ -214,14 +243,31 @@ export class MockSecureGateway extends TypedEventEmitter<GatewayEvents> {
 		const dstAddress = new KNXAddress(dst, KNXAddressType.TYPE_GROUP)
 		const apci = 0x80 | (value ? 0x01 : 0x00)
 		const npdu = new NPDU(0x00, apci, null)
+		const prevSeq = this.sendSeq48
+		if (forceSeq !== undefined) this.sendSeq48 = forceSeq
+		const seq48 = this.sendSeq48
 		this.applyDataSecure(npdu, control, this.interfaceIa, dst, key)
+		if (forceSeq !== undefined) this.sendSeq48 = prevSeq
 		const cemi = new LDataInd(null, control, srcAddress, dstAddress, npdu)
 		const request = KNXProtocol.newKNXTunnelingRequest(
 			this.channelId,
 			this.nextTunnelSeq(),
 			cemi,
 		)
-		this.socket.write(this.wrapFrame(request.toBuffer()))
+		return { inner: request.toBuffer(), seq48 }
+	}
+
+	/** Wrap an arbitrary inner KNX/IP frame in a fresh SecureWrapper. */
+	wrapInner(inner: Buffer): Buffer {
+		return this.wrapFrame(inner)
+	}
+
+	/** Send raw bytes directly on the socket, bypassing wrapping. */
+	writeRaw(buf: Buffer): void {
+		if (!this.socket) {
+			throw new Error('No socket')
+		}
+		this.socket.write(buf)
 	}
 
 	private handleConnection(socket: Socket) {
@@ -298,14 +344,53 @@ export class MockSecureGateway extends TypedEventEmitter<GatewayEvents> {
 		})
 		const sessionHash = crypto.createHash('sha256').update(secret).digest()
 		this.sessionKey = sessionHash.subarray(0, 16)
-		const responseLen = KNXIP_HEADER_AND_BODY_LEN(2 + PUBLIC_KEY_LEN)
-		const response = Buffer.concat([
+		// Body = session id (2) + server public key (32) + optional MAC (16).
+		const bodyLen =
+			2 + PUBLIC_KEY_LEN + (this.deviceAuthCode ? MAC_LEN_FULL : 0)
+		const responseLen = KNXIP_HEADER_AND_BODY_LEN(bodyLen)
+		let response = Buffer.concat([
 			Buffer.from('06100952', 'hex'),
 			Buffer.from([responseLen >> 8, responseLen & 0xff]),
 			Buffer.from([this.sessionId >> 8, this.sessionId & 0xff]),
 			this.serverPublicKeyRaw,
 		])
+		if (this.deviceAuthCode) {
+			response = Buffer.concat([
+				response,
+				this.buildSessionResponseMac(responseLen),
+			])
+		}
 		this.socket?.write(response)
+	}
+
+	// Build the SESSION_RESPONSE MAC (device authentication) over the XOR of the
+	// client and server public values and the session id, matching the verifier
+	// in KNXClient.secureVerifySessionResponse.
+	private buildSessionResponseMac(totalLen: number): Buffer {
+		if (!this.deviceAuthCode || !this.clientPublicKey)
+			return Buffer.alloc(0)
+		const xor = Buffer.alloc(PUBLIC_KEY_LEN)
+		for (let i = 0; i < PUBLIC_KEY_LEN; i++)
+			xor[i] = this.clientPublicKey[i] ^ this.serverPublicKeyRaw[i]
+		const additionalData = Buffer.concat([
+			KNXIP_HDR_SECURE_SESSION_RESPONSE,
+			Buffer.from([(totalLen >> 8) & 0xff, totalLen & 0xff]),
+			Buffer.from([(this.sessionId >> 8) & 0xff, this.sessionId & 0xff]),
+			xor,
+		])
+		const block0 = Buffer.alloc(AES_BLOCK_LEN, 0)
+		const macCbc = calculateMessageAuthenticationCodeCBC(
+			this.deviceAuthCode,
+			additionalData,
+			Buffer.alloc(0),
+			block0,
+		)
+		const ctr = crypto.createCipheriv(
+			'aes-128-ctr',
+			this.deviceAuthCode,
+			AUTH_CTR_IV,
+		)
+		return ctr.update(macCbc)
 	}
 
 	private handleSecureWrapper(frame: Buffer) {
@@ -495,7 +580,8 @@ export class MockSecureGateway extends TypedEventEmitter<GatewayEvents> {
 			addrFields,
 			Buffer.from([
 				0x00,
-				flags16 & 0xff,
+				// Only the relevant CTRL2 bits are covered by the Data Secure MAC.
+				flags16 & 0xff & SEC_CEMI.CTRL2_RELEVANT_MASK,
 				(TPCI_DATA << 2) + APCI_SEC.HIGH,
 				APCI_SEC.LOW,
 				0x00,

--- a/test/secure/secureTunnel.test.ts
+++ b/test/secure/secureTunnel.test.ts
@@ -17,6 +17,8 @@ import KNXClient, {
 	type SecureConfig,
 } from '../../src/KNXClient'
 import CEMIConstants from '../../src/protocol/cEMI/CEMIConstants'
+import { Keyring } from '../../src/secure/keyring'
+import { deriveDeviceAuthenticationPassword } from '../../src/secure/security_primitives'
 import { MockSecureGateway } from './MockSecureGateway'
 
 const KEYRING_XML = `<?xml version="1.0" encoding="utf-8"?>
@@ -69,6 +71,24 @@ describe('KNX Secure Tunnel', () => {
 })
 
 async function runSecureTunnelScenario(secureTunnelConfig: SecureConfig) {
+	// Derive the same device authentication code the client gets from the keyring,
+	// so the mock gateway can emit a verifiable SESSION_RESPONSE MAC.
+	const kr = new Keyring()
+	if (secureTunnelConfig.knxkeys_buffer) {
+		await kr.loadFromBuffer(
+			secureTunnelConfig.knxkeys_buffer,
+			secureTunnelConfig.knxkeys_password!,
+		)
+	} else {
+		await kr.load(
+			secureTunnelConfig.knxkeys_file_path!,
+			secureTunnelConfig.knxkeys_password!,
+		)
+	}
+	const ifaceAuth = kr.getInterface('1.1.1')?.decryptedAuthentication
+	assert.ok(ifaceAuth, 'keyring should expose interface authentication')
+	const deviceAuthCode = deriveDeviceAuthenticationPassword(ifaceAuth!)
+
 	const gateway = new MockSecureGateway({
 		groupKeys: {
 			'1/2/3': Buffer.from('00112233445566778899aabbccddeeff', 'hex'),
@@ -76,6 +96,7 @@ async function runSecureTunnelScenario(secureTunnelConfig: SecureConfig) {
 		interfaceIndividualAddress: '1.1.1',
 		tunnelAssignedIndividualAddress: '10.15.251',
 		serial: Buffer.from('010203040506', 'hex'),
+		deviceAuthCode,
 	})
 	await gateway.start()
 

--- a/test/secure/secureValidation.test.ts
+++ b/test/secure/secureValidation.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests that the KNX Secure receive path rejects forged, replayed and
+ * tampered traffic (regression tests for the security hardening of the
+ * unicast SecureWrapper, SESSION_RESPONSE and Data Secure paths).
+ *
+ * Written in Italy with love, sun and passion, by Massimo Saccani.
+ *
+ * Released under the MIT License.
+ * Use at your own risk; the author assumes no liability for damages.
+ */
+
+import { describe, it, before, after, afterEach } from 'node:test'
+import assert from 'assert'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import KNXClient, { KNXClientEvents } from '../../src/KNXClient'
+import CEMIConstants from '../../src/protocol/cEMI/CEMIConstants'
+import { Keyring } from '../../src/secure/keyring'
+import { deriveDeviceAuthenticationPassword } from '../../src/secure/security_primitives'
+import { MockSecureGateway } from './MockSecureGateway'
+
+const KEYRING_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Keyring CreatedBy="UnitTest" Created="2024-10-03T12:34:56Z">
+  <Interface Type="Tunnelling" IndividualAddress="1.1.1" UserID="5" Password="9b1seR1kYPayZxTITA4mq3oRNSdkelNCOnHA0jtZK6g=" Authentication="6/b5wvUrvyg4J+JH+J3EPvaGbIug0amjx5PMHkztZUQ=">
+    <Group Address="1/2/3" Senders="1.1.1 1.1.10" />
+  </Interface>
+  <Backbone Key="XvI24ir4JEE0cxRMsMKtbw==" Latency="20" MulticastAddress="224.0.23.12" />
+  <GroupAddresses>
+    <Group Address="1/2/3" Key="DFZA8HL9wnFWS3LGw40k/w==" />
+  </GroupAddresses>
+  <Devices>
+    <Device IndividualAddress="1.1.10" ToolKey="dxJwaArmxpY3eftE9Qzj3Q==" ManagementPassword="pijNuGYx6LA+7ZJ4vyWtUMTfuPFXEIEL5A8lmHadX6A=" Authentication="dMWy3GlA8iHV7cflIRyp7S0dBxyEiHFTWIE7qdMh6u4=" SequenceNumber="42" SerialNumber="010203040506" />
+  </Devices>
+</Keyring>`
+
+const GROUP_KEY = Buffer.from('00112233445566778899aabbccddeeff', 'hex')
+const GA = '1/2/3'
+
+const delay = (ms: number) =>
+	new Promise<void>((r) => {
+		setTimeout(r, ms)
+	})
+
+describe('KNX Secure validation (negative paths)', () => {
+	let tmpDir: string
+	let keyringPath: string
+	let deviceAuthCode: Buffer
+
+	let gateway: MockSecureGateway | undefined
+	let client: KNXClient | undefined
+
+	before(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'knx-secure-neg-'))
+		keyringPath = path.join(tmpDir, 'test.knxkeys')
+		fs.writeFileSync(keyringPath, KEYRING_XML, 'utf8')
+		const kr = new Keyring()
+		await kr.load(keyringPath, 'knxPassword')
+		const auth = kr.getInterface('1.1.1')?.decryptedAuthentication
+		assert.ok(auth, 'keyring should expose interface authentication')
+		deviceAuthCode = deriveDeviceAuthenticationPassword(auth!)
+	})
+
+	after(() => {
+		try {
+			fs.rmSync(tmpDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	afterEach(async () => {
+		if (client) {
+			try {
+				await client.Disconnect()
+			} catch {}
+			client = undefined
+		}
+		if (gateway) {
+			try {
+				await gateway.stop()
+			} catch {}
+			gateway = undefined
+		}
+	})
+
+	// Build a client + (already connected) gateway, unless connect is expected
+	// to fail (waitConnected=false).
+	async function setup(
+		gatewayDeviceAuthCode: Buffer | undefined,
+		waitConnected = true,
+	): Promise<{ gw: MockSecureGateway; cli: KNXClient }> {
+		const gw = new MockSecureGateway({
+			groupKeys: { [GA]: GROUP_KEY },
+			interfaceIndividualAddress: '1.1.1',
+			tunnelAssignedIndividualAddress: '10.15.251',
+			serial: Buffer.from('010203040506', 'hex'),
+			deviceAuthCode: gatewayDeviceAuthCode,
+		})
+		await gw.start()
+		const addr = gw.address!
+		const cli = new KNXClient({
+			hostProtocol: 'TunnelTCP',
+			ipAddr: addr.address === '::' ? '127.0.0.1' : addr.address,
+			ipPort: addr.port,
+			isSecureKNXEnabled: true,
+			secureTunnelConfig: {
+				knxkeys_file_path: keyringPath,
+				knxkeys_password: 'knxPassword',
+				tunnelInterfaceIndividualAddress: '1.1.1',
+			},
+			loglevel: 'error',
+		})
+		gateway = gw
+		client = cli
+		if (waitConnected) {
+			const connected = new Promise<void>((resolve) => {
+				cli.once(KNXClientEvents.connected, () => resolve())
+			})
+			cli.Connect()
+			await connected
+		}
+		return { gw, cli }
+	}
+
+	// Collects decoded GA=1/2/3 indications.
+	function collectIndications(cli: KNXClient): boolean[] {
+		const out: boolean[] = []
+		cli.on('indication', (packet: any) => {
+			const cemi = packet?.cEMIMessage
+			if (cemi?.msgCode !== CEMIConstants.L_DATA_IND) return
+			if (cemi.dstAddress?.toString?.() !== GA) return
+			const value = (cemi.npdu?.dataValue?.[0] ?? 0) & 0x01
+			out.push(value === 1)
+		})
+		return out
+	}
+
+	it('rejects a forged SESSION_RESPONSE with an invalid device-auth MAC', async () => {
+		// Gateway signs the SESSION_RESPONSE with the WRONG device auth code.
+		const wrongCode = Buffer.alloc(16, 0xab)
+		const { cli } = await setup(wrongCode, false)
+
+		const result = await new Promise<'connected' | 'error'>((resolve) => {
+			const t = setTimeout(() => resolve('error'), 2500)
+			cli.once(KNXClientEvents.connected, () => {
+				clearTimeout(t)
+				resolve('connected')
+			})
+			cli.once(KNXClientEvents.error, () => {
+				clearTimeout(t)
+				resolve('error')
+			})
+			cli.Connect()
+		})
+
+		assert.strictEqual(
+			result,
+			'error',
+			'client must not connect on a forged SESSION_RESPONSE',
+		)
+	})
+
+	it('drops a replayed SecureWrapper (identical bytes resent)', async () => {
+		const { gw, cli } = await setup(deviceAuthCode)
+		const indications = collectIndications(cli)
+
+		const { inner } = gw.buildSecureGroupWriteInner(GA, true)
+		const wrapper = gw.wrapInner(inner)
+		gw.writeRaw(wrapper) // legitimate
+		gw.writeRaw(wrapper) // replay: same wrapper sequence
+		await delay(400)
+
+		assert.strictEqual(
+			indications.length,
+			1,
+			'replayed wrapper must be dropped (only one indication expected)',
+		)
+	})
+
+	it('drops a SecureWrapper whose MAC has been tampered', async () => {
+		const { gw, cli } = await setup(deviceAuthCode)
+		const indications = collectIndications(cli)
+
+		const { inner } = gw.buildSecureGroupWriteInner(GA, true)
+		const wrapper = gw.wrapInner(inner)
+		const tampered = Buffer.from(wrapper)
+		tampered[tampered.length - 1] ^= 0xff // flip a MAC byte
+		gw.writeRaw(tampered)
+		await delay(300)
+		assert.strictEqual(
+			indications.length,
+			0,
+			'tampered wrapper must be dropped',
+		)
+
+		// A subsequent valid telegram is still processed (session survives).
+		await gw.sendGroupValueWriteSecure(GA, true)
+		await delay(300)
+		assert.strictEqual(
+			indications.length,
+			1,
+			'valid telegram after a tampered one must still be processed',
+		)
+	})
+
+	it('drops a replayed Data Secure telegram (same seq in a fresh wrapper)', async () => {
+		const { gw, cli } = await setup(deviceAuthCode)
+		const indications = collectIndications(cli)
+
+		// First telegram with sender sequence N.
+		const first = gw.buildSecureGroupWriteInner(GA, true)
+		gw.writeRaw(gw.wrapInner(first.inner))
+		await delay(250)
+		assert.strictEqual(indications.length, 1, 'first telegram accepted')
+
+		// Replay the SAME Data Secure sequence inside a brand-new wrapper: the
+		// wrapper freshness passes but Data Secure freshness must reject it.
+		const replay = gw.buildSecureGroupWriteInner(GA, true, first.seq48)
+		gw.writeRaw(gw.wrapInner(replay.inner))
+		await delay(250)
+		assert.strictEqual(
+			indications.length,
+			1,
+			'replayed Data Secure telegram must be dropped',
+		)
+	})
+
+	it('drops plaintext KNX/IP frames inside the secure session', async () => {
+		const { gw, cli } = await setup(deviceAuthCode)
+		const indications = collectIndications(cli)
+
+		// Plaintext CONNECT_RESPONSE (06 10 02 06 | len=0x14 | ch status | HPAI | CRD)
+		// injected unwrapped; total length field (0x0014 = 20) matches its bytes.
+		const plainConnectResponse = Buffer.from(
+			'061002060014510008017f0000010e5704040200',
+			'hex',
+		)
+		assert.strictEqual(
+			plainConnectResponse.length,
+			0x14,
+			'plaintext test frame length must match its header',
+		)
+		gw.writeRaw(plainConnectResponse)
+		await delay(300)
+
+		// Session must stay alive and still process a valid wrapped telegram.
+		await gw.sendGroupValueWriteSecure(GA, true)
+		await delay(300)
+		assert.strictEqual(
+			indications.length,
+			1,
+			'plaintext frame must be ignored but the session must keep working',
+		)
+	})
+})


### PR DESCRIPTION
BREAKING CHANGE: the KNX/IP Secure and Data Secure receive path is now cryptographically validated. Frames that fail authentication or freshness checks are dropped instead of emitted as indication events.

- Verify SESSION_RESPONSE device-authentication MAC during the unicast handshake; a forged response aborts the connection.
- Verify SecureWrapper MAC and enforce a strictly increasing wrapper sequence per session (anti-replay); invalid/replayed wrappers dropped.
- Enforce Data Secure per-source 48-bit anti-replay and reject telegrams with an invalid MAC.
- Drop plaintext KNX/IP frames inside an established secure session.
- Data Secure sender sequence no longer wraps: throws when the 48-bit maximum is reached.
- New optional secureTunnelConfig.deviceAuthenticationPassword for manual (no keyring) configurations.

Bump to 6.0.0, update CHANGELOG and add README warning.